### PR TITLE
Feat unacceptable travel detection on login

### DIFF
--- a/driver/registry_default.go
+++ b/driver/registry_default.go
@@ -96,6 +96,7 @@ type RegistryDefault struct {
 	hookShowVerificationUI  *hook.ShowVerificationUIHook
 	hookCodeAddressVerifier *hook.CodeAddressVerifier
 	hookTwoStepRegistration *hook.TwoStepRegistration
+	hookTeleportCheck       *hook.TeleportCheck
 
 	identityHandler        *identity.Handler
 	identityValidator      *identity.Validator

--- a/driver/registry_default_hooks.go
+++ b/driver/registry_default_hooks.go
@@ -15,6 +15,13 @@ func (m *RegistryDefault) HookVerifier() *hook.Verifier {
 	return m.hookVerifier
 }
 
+func (m *RegistryDefault) HookTeleportCheck() *hook.TeleportCheck {
+	if m.hookTeleportCheck == nil {
+		m.hookTeleportCheck = hook.NewTeleportCheck()
+	}
+	return m.hookTeleportCheck
+}
+
 func (m *RegistryDefault) HookCodeAddressVerifier() *hook.CodeAddressVerifier {
 	if m.hookCodeAddressVerifier == nil {
 		m.hookCodeAddressVerifier = hook.NewCodeAddressVerifier(m)
@@ -80,6 +87,8 @@ func (m *RegistryDefault) getHooks(credentialsType string, configs []config.Self
 			i = append(i, m.HookTwoStepRegistration())
 		case hook.KeyVerifier:
 			i = append(i, m.HookVerifier())
+		case hook.KeyTeleportCheck:
+			i = append(i, m.HookTeleportCheck())
 		default:
 			var found bool
 			for name, m := range m.injectedSelfserviceHooks {

--- a/selfservice/flow/login/error.go
+++ b/selfservice/flow/login/error.go
@@ -36,6 +36,8 @@ var (
 
 	// ErrSessionRequiredForHigherAAL is returned when someone requests AAL2 or AAL3 even though no active session exists yet.
 	ErrSessionRequiredForHigherAAL = herodot.ErrUnauthorized.WithID(text.ErrIDSessionRequiredForHigherAAL).WithError("aal2 and aal3 can only be requested if a session exists already").WithReason("You can not requested a higher AAL (AAL2/AAL3) without an active session.")
+
+	ErrTeleported = herodot.ErrUnauthorized.WithID(text.ErrIDLocationTeleport).WithError("there were two login attempts in short succession from locations distant from one another").WithReason("there were two login attempts in short succession from locations distant from one another")
 )
 
 type (

--- a/selfservice/hook/hooks.go
+++ b/selfservice/hook/hooks.go
@@ -11,4 +11,5 @@ const (
 	KeyVerificationUI      = "show_verification_ui"
 	KeyTwoStepRegistration = "two_step_registration"
 	KeyVerifier            = "verification"
+	KeyTeleportCheck       = "teleport_check"
 )

--- a/selfservice/hook/teleport_check.go
+++ b/selfservice/hook/teleport_check.go
@@ -10,9 +10,22 @@ import (
 	"github.com/ory/x/otelx"
 )
 
-var _ login.PostHookExecutor = new(TeleportCheck)
+var (
+	_                login.PostHookExecutor = new(TeleportCheck)
+	locationToLatLng                        = map[string]LatLng{
+		"Munich, Germany":             {48.137154, 11.576124},
+		"Paris, France":               {48.864716, 2.349014},
+		"Taufkirchen, Germany":        {48.14927, 12.45652},
+		"Taufkirchen (Vils), Germany": {48.34347, 12.13063},
+		// TODO: more.
+	}
+)
 
 type (
+	LatLng struct {
+		Latitude  float64
+		Longitude float64
+	}
 	TeleportCheck struct {
 	}
 )
@@ -21,9 +34,48 @@ func NewTeleportCheck() *TeleportCheck {
 	return &TeleportCheck{}
 }
 
+func haversineDistance(a, b LatLng) float64 {
+	// TODO
+	return 0.0
+}
+
 func (e *TeleportCheck) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Request, _ node.UiNodeGroup, _ *login.Flow, s *session.Session) error {
 	return otelx.WithSpan(r.Context(), "selfservice.hook.TeleportCheck.ExecuteLoginPostHook", func(ctx context.Context) error {
-		// TODO
+		// If there is zero or one location, nothing to check.
+		if len(s.Devices) <= 1 {
+			return nil
+		}
+
+		locationPrevious := s.Devices[len(s.Devices)-2].Location
+		locationCurrent := s.Devices[len(s.Devices)-1].Location
+
+		latLngPrevious, ok := locationToLatLng[*locationPrevious]
+		if !ok {
+			return nil
+		}
+
+		latLngCurrent, ok := locationToLatLng[*locationCurrent]
+		if !ok {
+			return nil
+		}
+
+		distance := haversineDistance(latLngPrevious, latLngCurrent)
+
+		timePrevious := s.Devices[len(s.Devices)-2].CreatedAt
+		timeCurrent := s.Devices[len(s.Devices)-1].CreatedAt
+		duration := timeCurrent.Sub(timePrevious).Seconds()
+
+		// TODO: Avoid divide by zero.
+		speedMeterPerSecond := distance / duration
+
+		// TODO: Move to configuration.
+		maxAcceptableSpeedKilometerPerHour := float64(1000)
+		maxAcceptableSpeedMeterPerSecond := maxAcceptableSpeedKilometerPerHour * 3.6
+
+		if speedMeterPerSecond > maxAcceptableSpeedMeterPerSecond {
+			return login.ErrTeleported
+		}
+
 		return nil
 	})
 }

--- a/selfservice/hook/teleport_check.go
+++ b/selfservice/hook/teleport_check.go
@@ -43,6 +43,9 @@ func DegPos(lat, lon float64) GeoPosition {
 	return GeoPosition{lat * math.Pi / 180, lon * math.Pi / 180}
 }
 
+// References:
+// - https://en.wikipedia.org/wiki/Haversine_formula
+// - https://rosettacode.org/wiki/Haversine_formula
 func HaversineDistanceMeters(p1, p2 GeoPosition) float64 {
 	rEarthMeters := 6372_800.0
 

--- a/selfservice/hook/teleport_check.go
+++ b/selfservice/hook/teleport_check.go
@@ -2,6 +2,7 @@ package hook
 
 import (
 	"context"
+	"math"
 	"net/http"
 
 	"github.com/ory/kratos/selfservice/flow/login"
@@ -11,20 +12,20 @@ import (
 )
 
 var (
-	_                login.PostHookExecutor = new(TeleportCheck)
-	locationToLatLng                        = map[string]LatLng{
-		"Munich, Germany":             {48.137154, 11.576124},
-		"Paris, France":               {48.864716, 2.349014},
-		"Taufkirchen, Germany":        {48.14927, 12.45652},
-		"Taufkirchen (Vils), Germany": {48.34347, 12.13063},
+	_                     login.PostHookExecutor = new(TeleportCheck)
+	locationToGeoPosition                        = map[string]GeoPosition{
+		"Munich, Germany":             DegPos(48.137154, 11.576124),
+		"Paris, France":               DegPos(48.864716, 2.349014),
+		"Taufkirchen, Germany":        DegPos(48.14927, 12.45652),
+		"Taufkirchen (Vils), Germany": DegPos(48.34347, 12.13063),
 		// TODO: more.
 	}
 )
 
 type (
-	LatLng struct {
-		Latitude  float64
-		Longitude float64
+	GeoPosition struct {
+		φ float64 // latitude, radians
+		ψ float64 // longitude, radians
 	}
 	TeleportCheck struct {
 	}
@@ -34,9 +35,19 @@ func NewTeleportCheck() *TeleportCheck {
 	return &TeleportCheck{}
 }
 
-func haversineDistance(a, b LatLng) float64 {
-	// TODO
-	return 0.0
+func haversine(θ float64) float64 {
+	return .5 * (1 - math.Cos(θ))
+}
+
+func DegPos(lat, lon float64) GeoPosition {
+	return GeoPosition{lat * math.Pi / 180, lon * math.Pi / 180}
+}
+
+func HaversineDistanceMeters(p1, p2 GeoPosition) float64 {
+	rEarthMeters := 6372_800.0
+
+	return 2 * rEarthMeters * math.Asin(math.Sqrt(haversine(p2.φ-p1.φ)+
+		math.Cos(p1.φ)*math.Cos(p2.φ)*haversine(p2.ψ-p1.ψ)))
 }
 
 func (e *TeleportCheck) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Request, _ node.UiNodeGroup, _ *login.Flow, s *session.Session) error {
@@ -49,17 +60,17 @@ func (e *TeleportCheck) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Requ
 		locationPrevious := s.Devices[len(s.Devices)-2].Location
 		locationCurrent := s.Devices[len(s.Devices)-1].Location
 
-		latLngPrevious, ok := locationToLatLng[*locationPrevious]
+		geoPositionPrevious, ok := locationToGeoPosition[*locationPrevious]
 		if !ok {
 			return nil
 		}
 
-		latLngCurrent, ok := locationToLatLng[*locationCurrent]
+		geoPositionCurrent, ok := locationToGeoPosition[*locationCurrent]
 		if !ok {
 			return nil
 		}
 
-		distance := haversineDistance(latLngPrevious, latLngCurrent)
+		distance := HaversineDistanceMeters(geoPositionPrevious, geoPositionCurrent)
 
 		timePrevious := s.Devices[len(s.Devices)-2].CreatedAt
 		timeCurrent := s.Devices[len(s.Devices)-1].CreatedAt

--- a/selfservice/hook/teleport_check.go
+++ b/selfservice/hook/teleport_check.go
@@ -11,11 +11,20 @@ import (
 	"github.com/ory/x/otelx"
 )
 
+// The teleport check is a post login hook that verifies that the user did not 'teleport',
+// i.e. did not attempt subsequent logins from two very far away locations in 'short' succession.
+// 'Short' here is not thought in terms of time but instead, in terms of speed.
+// If the user would have needed to go faster than a commercial plane to go from the previous location
+// to the current one, we reject it.
+
 var (
-	_                     login.PostHookExecutor = new(TeleportCheck)
-	locationToGeoPosition                        = map[string]GeoPosition{
-		"Munich, Germany":             DegPos(48.137154, 11.576124),
-		"Paris, France":               DegPos(48.864716, 2.349014),
+	_ login.PostHookExecutor = new(TeleportCheck)
+	// We keep in-memory a compile time, read-only mapping of the location in a free flowing string format,
+	// to a latitude and longitude (stored in radians but that is an implementation detail).
+	locationToGeoPosition = map[string]GeoPosition{
+		"Munich, Germany": DegPos(48.137154, 11.576124),
+		"Paris, France":   DegPos(48.864716, 2.349014),
+		// The string does not require a specific formatting:
 		"Taufkirchen, Germany":        DegPos(48.14927, 12.45652),
 		"Taufkirchen (Vils), Germany": DegPos(48.34347, 12.13063),
 		// TODO: more.
@@ -24,6 +33,7 @@ var (
 
 type (
 	GeoPosition struct {
+		// Optimization: we could use f32 or even f16.
 		φ float64 // latitude, radians
 		ψ float64 // longitude, radians
 	}
@@ -35,6 +45,9 @@ func NewTeleportCheck() *TeleportCheck {
 	return &TeleportCheck{}
 }
 
+// Math references:
+// - https://en.wikipedia.org/wiki/Haversine_formula
+// - https://rosettacode.org/wiki/Haversine_formula
 func haversine(θ float64) float64 {
 	return .5 * (1 - math.Cos(θ))
 }
@@ -43,9 +56,6 @@ func DegPos(lat, lon float64) GeoPosition {
 	return GeoPosition{lat * math.Pi / 180, lon * math.Pi / 180}
 }
 
-// References:
-// - https://en.wikipedia.org/wiki/Haversine_formula
-// - https://rosettacode.org/wiki/Haversine_formula
 func HaversineDistanceMeters(p1, p2 GeoPosition) float64 {
 	rEarthMeters := 6372_800.0
 
@@ -55,11 +65,13 @@ func HaversineDistanceMeters(p1, p2 GeoPosition) float64 {
 
 func (e *TeleportCheck) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Request, _ node.UiNodeGroup, _ *login.Flow, s *session.Session) error {
 	return otelx.WithSpan(r.Context(), "selfservice.hook.TeleportCheck.ExecuteLoginPostHook", func(ctx context.Context) error {
-		// If there is zero or one location, nothing to check.
+		// If there is zero or one location, nothing we can check.
 		if len(s.Devices) <= 1 {
 			return nil
 		}
 
+		// We assume that the check has been run for all previous location.
+		// Hence we only need to check the new (i.e. 'current') one with the previous one.
 		locationPrevious := s.Devices[len(s.Devices)-2].Location
 		locationCurrent := s.Devices[len(s.Devices)-1].Location
 
@@ -87,7 +99,8 @@ func (e *TeleportCheck) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Requ
 
 		speedMeterPerSecond := distance / duration
 
-		// TODO: Move to configuration.
+		// TODO: Move this constant to configuration?
+		// That is the top speed of a commercial plane.
 		maxAcceptableSpeedKilometerPerHour := float64(1000)
 		maxAcceptableSpeedMeterPerSecond := maxAcceptableSpeedKilometerPerHour * 3.6
 

--- a/selfservice/hook/teleport_check.go
+++ b/selfservice/hook/teleport_check.go
@@ -1,0 +1,29 @@
+package hook
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ory/kratos/selfservice/flow/login"
+	"github.com/ory/kratos/session"
+	"github.com/ory/kratos/ui/node"
+	"github.com/ory/x/otelx"
+)
+
+var _ login.PostHookExecutor = new(TeleportCheck)
+
+type (
+	TeleportCheck struct {
+	}
+)
+
+func NewTeleportCheck() *TeleportCheck {
+	return &TeleportCheck{}
+}
+
+func (e *TeleportCheck) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Request, _ node.UiNodeGroup, _ *login.Flow, s *session.Session) error {
+	return otelx.WithSpan(r.Context(), "selfservice.hook.TeleportCheck.ExecuteLoginPostHook", func(ctx context.Context) error {
+		// TODO
+		return nil
+	})
+}

--- a/selfservice/hook/teleport_check.go
+++ b/selfservice/hook/teleport_check.go
@@ -60,6 +60,7 @@ func (e *TeleportCheck) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Requ
 		locationPrevious := s.Devices[len(s.Devices)-2].Location
 		locationCurrent := s.Devices[len(s.Devices)-1].Location
 
+		// Fail open: if the location is absent/unknown, it is ok.
 		geoPositionPrevious, ok := locationToGeoPosition[*locationPrevious]
 		if !ok {
 			return nil
@@ -76,7 +77,11 @@ func (e *TeleportCheck) ExecuteLoginPostHook(_ http.ResponseWriter, r *http.Requ
 		timeCurrent := s.Devices[len(s.Devices)-1].CreatedAt
 		duration := timeCurrent.Sub(timePrevious).Seconds()
 
-		// TODO: Avoid divide by zero.
+		// Avoid divide by zero later.
+		if duration == 0 {
+			duration = math.SmallestNonzeroFloat64
+		}
+
 		speedMeterPerSecond := distance / duration
 
 		// TODO: Move to configuration.

--- a/selfservice/hook/teleport_check_test.go
+++ b/selfservice/hook/teleport_check_test.go
@@ -1,0 +1,65 @@
+package hook_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gobuffalo/httptest"
+	"github.com/ory/kratos/selfservice/flow/login"
+	"github.com/ory/kratos/selfservice/hook"
+	"github.com/ory/kratos/session"
+	"github.com/ory/kratos/ui/node"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHaversineDistance(t *testing.T) {
+	p1 := hook.DegPos(36.12, -86.67)
+	p2 := hook.DegPos(33.94, -118.40)
+	dist := hook.HaversineDistanceMeters(p1, p2)
+
+	require.InEpsilon(t, 2887259.0, dist, 0.1)
+}
+
+func str(s string) *string {
+	res := s
+	return &res
+}
+
+func teleportCheckWithDevices(devices []session.Device) error {
+	w := httptest.NewRecorder()
+	var r http.Request
+	f := &login.Flow{}
+	var n node.UiNodeGroup
+
+	h := hook.NewTeleportCheck()
+	s := session.Session{
+		Devices: devices,
+	}
+	err := h.ExecuteLoginPostHook(w, &r, n, f, &s)
+	return err
+}
+
+func TestHookTeleportCheckLessThanTwoDevices(t *testing.T) {
+	require.NoError(t, teleportCheckWithDevices([]session.Device{}))
+	now := time.Now()
+	require.NoError(t, teleportCheckWithDevices([]session.Device{
+		{Location: str("Munich, Germany"), CreatedAt: now},
+	}))
+}
+
+func TestHookTeleportCheckDistanceOk(t *testing.T) {
+	now := time.Now()
+	require.NoError(t, teleportCheckWithDevices([]session.Device{
+		{Location: str("Munich, Germany"), CreatedAt: now},
+		{Location: str("Paris, France"), CreatedAt: now.Add(5 * time.Hour)},
+	}))
+}
+
+func TestHookTeleportCheckTooMuchDistance(t *testing.T) {
+	now := time.Now()
+	require.Error(t, teleportCheckWithDevices([]session.Device{
+		{Location: str("Munich, Germany"), CreatedAt: now},
+		{Location: str("Paris, France"), CreatedAt: now.Add(1 * time.Second)},
+	}))
+}

--- a/selfservice/hook/teleport_check_test.go
+++ b/selfservice/hook/teleport_check_test.go
@@ -48,6 +48,24 @@ func TestHookTeleportCheckLessThanTwoDevices(t *testing.T) {
 	}))
 }
 
+func TestHookTeleportCheckAbsentOrUnknownLocation(t *testing.T) {
+	require.NoError(t, teleportCheckWithDevices([]session.Device{}))
+	now := time.Now()
+	require.NoError(t, teleportCheckWithDevices([]session.Device{
+		{Location: str("Munich, Germany"), CreatedAt: now},
+		{Location: str("foobar"), CreatedAt: now},
+	}))
+}
+
+func TestHookTeleportCheckZeroDuration(t *testing.T) {
+	require.NoError(t, teleportCheckWithDevices([]session.Device{}))
+	now := time.Now()
+	require.Error(t, teleportCheckWithDevices([]session.Device{
+		{Location: str("Munich, Germany"), CreatedAt: now},
+		{Location: str("Paris, France"), CreatedAt: now},
+	}))
+}
+
 func TestHookTeleportCheckDistanceOk(t *testing.T) {
 	now := time.Now()
 	require.NoError(t, teleportCheckWithDevices([]session.Device{

--- a/text/message_error.go
+++ b/text/message_error.go
@@ -20,6 +20,7 @@ const (
 	ErrNoActiveSession               = "session_inactive"
 	ErrIDRedirectURLNotAllowed       = "self_service_flow_return_to_forbidden"
 	ErrIDInitiatedBySomeoneElse      = "security_identity_mismatch"
+	ErrIDLocationTeleport            = "session_location_teleport"
 
 	ErrIDCSRF = "security_csrf_violation"
 )


### PR DESCRIPTION
# Problem

We want to detect, on a login attempt, that the user did not 'teleport',
i.e. did not attempt subsequent logins from two very far away locations in 'short' succession.
'Short' here is not thought in terms of time but instead, in terms of speed.
If the user would have needed to go faster than a commercial plane to go from the previous location
to the current one, we reject it.

The catchy name for this feature is 'teleport check'.

# Proposed solution

Inspired by https://www.ory.sh/docs/identities/sign-in/actions#control-who-registers-with-additional-validation, we add a new post login hook. It inspects, for a given session, the previous and current locations, computes the distance between the two, and rejects the login if the speed to go from one location to the other is above a given threshold. 

Implementing this as a hook makes it optional to use, self-contained, and toggleable through configuration. 

The database is not queried, it all runs in memory, in order to not incur additional latency.

Unit tests have been added.

# Limitations and open questions

- The memory usage for the mapping of city/country to latitude/longitude can become a concern since it is kept in memory. However there are ways to optimize it so that each entry only requires <= 32 bytes. Also, this mapping need not be exhaustive and can only contain some cities, e.g. above 1000 inhabitants as a tradeoff.
- Only the current session is inspected, as a first milestone. This could be expanded to inspect past session(s), by querying the database, at the cost of a database round-trip (perhaps alleviated through in-memory caching e.g. LRU).
- The acceptable speed threshold is hard-coded for now but could be exposed in the configuration if needed.
- End to end tests and user-facing docs are left to do.
   
